### PR TITLE
bug fix: the character cannot double jump underwater now

### DIFF
--- a/Assets/Scripts/Abilities/AbilityDoubleJump.cs
+++ b/Assets/Scripts/Abilities/AbilityDoubleJump.cs
@@ -59,7 +59,7 @@ public class AbilityDoubleJump : Ability
     }
     void DJump()
     {
-        if (_Controller.isGrounded == false && currentjump < MAX_DJUMP && !Grapplecheck())//only trigger when player not on ground
+        if (_Controller.isGrounded == false && currentjump < MAX_DJUMP)//only trigger when player not on ground
         {
             GetComponent<PlayerSoundManager>().StopSounds();
             GetComponent<PlayerSoundManager>().SetSoundOfName(PlayerSoundManager.SoundTypes.jump);

--- a/Assets/Scripts/Abilities/AbilityDoubleJump.cs
+++ b/Assets/Scripts/Abilities/AbilityDoubleJump.cs
@@ -58,13 +58,8 @@ public class AbilityDoubleJump : Ability
             return false;
     }
     void DJump()
-<<<<<<< HEAD
-    {
-        if (_Controller.isGrounded == false && currentjump < MAX_DJUMP)//only trigger when player not on ground
-=======
     {        
         if (_Controller.isGrounded == false && currentjump < MAX_DJUMP && !Grapplecheck() && !UnderwaterManager.isUnderwater)//only trigger when player not on ground
->>>>>>> bd23f788a4499d2ad08bb45cd95ace53b0ae7f8d
         {
             GetComponent<PlayerSoundManager>().StopSounds();
             GetComponent<PlayerSoundManager>().SetSoundOfName(PlayerSoundManager.SoundTypes.jump);

--- a/Assets/Scripts/Abilities/AbilityDoubleJump.cs
+++ b/Assets/Scripts/Abilities/AbilityDoubleJump.cs
@@ -41,7 +41,7 @@ public class AbilityDoubleJump : Ability
     }
     void DJump()
     {
-        if (_Controller.isGrounded == false && currentjump < MAX_DJUMP && !UnderwaterManager.isUnderwater)//only trigger when player not on ground
+        if (_Controller.isGrounded == false && currentjump < MAX_DJUMP)//only trigger when player not on ground
         {
             GetComponent<PlayerSoundManager>().StopSounds();
             GetComponent<PlayerSoundManager>().SetSoundOfName(PlayerSoundManager.SoundTypes.jump);

--- a/Assets/Scripts/Abilities/AbilityDoubleJump.cs
+++ b/Assets/Scripts/Abilities/AbilityDoubleJump.cs
@@ -41,7 +41,7 @@ public class AbilityDoubleJump : Ability
     }
     void DJump()
     {
-        if (_Controller.isGrounded == false && currentjump < MAX_DJUMP)//only trigger when player not on ground
+        if (_Controller.isGrounded == false && currentjump < MAX_DJUMP && !UnderwaterManager.isUnderwater)//only trigger when player not on ground
         {
             GetComponent<PlayerSoundManager>().StopSounds();
             GetComponent<PlayerSoundManager>().SetSoundOfName(PlayerSoundManager.SoundTypes.jump);

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -181,18 +181,5 @@ public class PlayerMovement : MonoBehaviour
                 _JumpAmount.y = JumpHeight;
             }
         }       
-    }
-
-    private void JumpOrSwimming()
-    {
-        if (UnderwaterManager.isUnderwater == false)
-        {
-            Jump();
-        }
-        else
-        {
-            Debug.Log("Should swim");
-            Swimming();
-        }
-    }
+    }    
 }


### PR DESCRIPTION
1. bug fix: the character cannot double jump underwater now
(Moreover, if the character double jump on the water surface, there may be some small issues in a short time, such as the gravity and cannot swim until she fell to the ground, but the situation is better than before)